### PR TITLE
'Rounding bug in the iPhone app' Fix

### DIFF
--- a/Blockchain/SendViewController.m
+++ b/Blockchain/SendViewController.m
@@ -77,7 +77,7 @@
         from = [[fromAddress objectAtIndex:[fromField index]-1] addr];
     }
     
-    double value = [amountField.text doubleValue];
+    NSString * value = amountField.text;
     
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0ul), ^{
         @try {

--- a/Blockchain/Wallet.h
+++ b/Blockchain/Wallet.h
@@ -77,7 +77,7 @@
 
 -(id)initWithData:(NSData*)string password:(NSString*)password; //Restore wallet from base64 data
 
--(void)sendPaymentTo:(NSString*)toAddress from:(NSString*)fromAddress value:(double)value;
+-(void)sendPaymentTo:(NSString*)toAddress from:(NSString*)fromAddress value:(NSString*)value;
 
 -(Key*)generateNewKey;
 

--- a/Blockchain/Wallet.m
+++ b/Blockchain/Wallet.m
@@ -60,10 +60,10 @@
     [webView stringByEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"parseWalletJSON('%@');", [self jsonString]]];
 }
 
--(void)sendPaymentTo:(NSString*)toAddress from:(NSString*)fromAddress value:(double)value {
+-(void)sendPaymentTo:(NSString*)toAddress from:(NSString*)fromAddress value:(NSString*)value {
     [self setJSVars];
    
-    [webView stringByEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"sendTx('%@', '%@', '%f');", toAddress, fromAddress, value]];
+    [webView stringByEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"sendTx('%@', '%@', '%@');", toAddress, fromAddress, value]];
 }
 
 


### PR DESCRIPTION
Solves this: https://bitcointalk.org/index.php?topic=40264.msg1435670#msg1435670

I've fixed the rounding bug in the iPhone app. It was a front-end issue where the front-end was taking the input, parsing it to a float and losing precision, then converting back to a string before sending it to the JS backend (which handles precision properly). The solution can be verified by sending 0.00070658 somewhere. On the old version, this would actually send 0.000707BTC. In this version, 0.00070658BTC will be sent as expected.

Please send the 2BTC bounty to 1FT7eT3S1ZnekDrbd3zVmS9WFdypnEeFqA as per https://bitcointalk.org/index.php?topic=135336.0
