### PR TITLE
Store guid and sharedKey in keychain.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		9FDAEF871514EDF500E92C90 /* modal_background_large.png in Resources */ = {isa = PBXBuildFile; fileRef = 9FDAEF851514EDF500E92C90 /* modal_background_large.png */; };
 		9FDAEF881514EDF500E92C90 /* modal_background_large2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 9FDAEF861514EDF500E92C90 /* modal_background_large2x.png */; };
 		9FDAEF8A1514EE0000E92C90 /* ModalView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9FDAEF891514EE0000E92C90 /* ModalView.xib */; };
+		A27005BF1993EE3F00F0136D /* KeychainItemWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = A27005BE1993EE3F00F0136D /* KeychainItemWrapper.m */; };
 		C92F761619803346007916F7 /* icon_512.png in Resources */ = {isa = PBXBuildFile; fileRef = C92F761519803346007916F7 /* icon_512.png */; };
 		C9BE917B1945D8F600FD516D /* PENumpadView.m in Sources */ = {isa = PBXBuildFile; fileRef = C9BE91681945D8F600FD516D /* PENumpadView.m */; };
 		C9BE917C1945D8F600FD516D /* PEPinEntryController.m in Sources */ = {isa = PBXBuildFile; fileRef = C9BE916A1945D8F600FD516D /* PEPinEntryController.m */; };
@@ -429,6 +430,8 @@
 		9FDAEF851514EDF500E92C90 /* modal_background_large.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = modal_background_large.png; sourceTree = "<group>"; };
 		9FDAEF861514EDF500E92C90 /* modal_background_large2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = modal_background_large2x.png; sourceTree = "<group>"; };
 		9FDAEF891514EE0000E92C90 /* ModalView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ModalView.xib; sourceTree = "<group>"; };
+		A27005BD1993EE3F00F0136D /* KeychainItemWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeychainItemWrapper.h; sourceTree = "<group>"; };
+		A27005BE1993EE3F00F0136D /* KeychainItemWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KeychainItemWrapper.m; sourceTree = "<group>"; };
 		C92F761519803346007916F7 /* icon_512.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon_512.png; sourceTree = "<group>"; };
 		C9BE91671945D8F600FD516D /* PENumpadView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PENumpadView.h; sourceTree = "<group>"; };
 		C9BE91681945D8F600FD516D /* PENumpadView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PENumpadView.m; sourceTree = "<group>"; };
@@ -839,6 +842,16 @@
 			path = zbar;
 			sourceTree = "<group>";
 		};
+		A27005BC1993EE3F00F0136D /* KeychainItemWrapper */ = {
+			isa = PBXGroup;
+			children = (
+				A27005BD1993EE3F00F0136D /* KeychainItemWrapper.h */,
+				A27005BE1993EE3F00F0136D /* KeychainItemWrapper.m */,
+			);
+			name = KeychainItemWrapper;
+			path = Library/KeychainItemWrapper;
+			sourceTree = "<group>";
+		};
 		C9B32CF9194F3F5800BDF3A0 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
@@ -917,6 +930,7 @@
 		C9D4B2AE193E020D00EDA9EA /* Third Party */ = {
 			isa = PBXGroup;
 			children = (
+				A27005BC1993EE3F00F0136D /* KeychainItemWrapper */,
 				84C25678198109AF00F901D1 /* Keys */,
 				9F749E061514F22500B3A8B8 /* libiconv.dylib */,
 				C9BE91651945D8F600FD516D /* PinEntry */,
@@ -1218,6 +1232,7 @@
 				C9BE917C1945D8F600FD516D /* PEPinEntryController.m in Sources */,
 				9F4A5092152F585E00F9ED9D /* UIDevice+Hardware.m in Sources */,
 				9F2780B715343A7D0015F83F /* UncaughtExceptionHandler.m in Sources */,
+				A27005BF1993EE3F00F0136D /* KeychainItemWrapper.m in Sources */,
 				C9C3998319885FAC001B3922 /* BCAlertView.m in Sources */,
 				84FC02FE19815F1B00B97D5B /* sha256.c in Sources */,
 				84CCFAAF197D859C00DA4482 /* NSString+NSString_EscapeQuotes.m in Sources */,

--- a/Blockchain/AppDelegate.h
+++ b/Blockchain/AppDelegate.h
@@ -43,7 +43,7 @@
 
 #define PIN_PBKDF2_ITERATIONS 1 //This does not need to be large because the key is already 256 bits
 
-@class TransactionsViewController, Wallet, BCFadeView, ReceiveCoinsViewController, AccountViewController, SendViewController, WebViewController, NewAccountView, MulitAddressResponse, PairingCodeParser, MerchantViewController;
+@class TransactionsViewController, Wallet, BCFadeView, ReceiveCoinsViewController, AccountViewController, SendViewController, WebViewController, NewAccountView, MulitAddressResponse, PairingCodeParser, MerchantViewController, KeychainItemWrapper;
 
 @interface AppDelegate : NSObject <UIApplicationDelegate, WalletDelegate, PEPinEntryControllerDelegate> {
     Wallet * wallet;
@@ -114,6 +114,8 @@
 
 @property(nonatomic, strong) NSNumberFormatter * btcFormatter;
 @property(nonatomic, strong) NSNumberFormatter * localCurrencyFormatter;
+
+@property (nonatomic, strong) KeychainItemWrapper *keychainItem;
 
 -(IBAction)manualPairClicked:(id)sender;
 -(void)setAccountData:(NSString*)guid sharedKey:(NSString*)sharedKey;

--- a/Library/KeychainItemWrapper/KeychainItemWrapper.h
+++ b/Library/KeychainItemWrapper/KeychainItemWrapper.h
@@ -1,0 +1,65 @@
+/*
+     File: KeychainItemWrapper.h
+ Abstract: 
+ Objective-C wrapper for accessing a single keychain item.
+ 
+  Version: 1.2 - ARCified
+ 
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+ 
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+ 
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+ 
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ 
+ Copyright (C) 2010 Apple Inc. All Rights Reserved.
+ 
+*/
+
+/*
+    The KeychainItemWrapper class is an abstraction layer for the iPhone Keychain communication. It is merely a 
+    simple wrapper to provide a distinct barrier between all the idiosyncracies involved with the Keychain
+    CF/NS container objects.
+*/
+@interface KeychainItemWrapper : NSObject
+
+// Designated initializer.
+- (id)initWithIdentifier: (NSString *)identifier accessGroup:(NSString *)accessGroup;
+- (void)setObject:(id)inObject forKey:(id)key;
+- (id)objectForKey:(id)key;
+
+// Initializes and resets the default generic keychain item data.
+- (void)resetKeychainItem;
+
+@end

--- a/Library/KeychainItemWrapper/KeychainItemWrapper.m
+++ b/Library/KeychainItemWrapper/KeychainItemWrapper.m
@@ -1,0 +1,311 @@
+/*
+     File: KeychainItemWrapper.m 
+ Abstract: 
+ Objective-C wrapper for accessing a single keychain item.
+  
+  Version: 1.2 - ARCified
+  
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple 
+ Inc. ("Apple") in consideration of your agreement to the following 
+ terms, and your use, installation, modification or redistribution of 
+ this Apple software constitutes acceptance of these terms.  If you do 
+ not agree with these terms, please do not use, install, modify or 
+ redistribute this Apple software. 
+  
+ In consideration of your agreement to abide by the following terms, and 
+ subject to these terms, Apple grants you a personal, non-exclusive 
+ license, under Apple's copyrights in this original Apple software (the 
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple 
+ Software, with or without modifications, in source and/or binary forms; 
+ provided that if you redistribute the Apple Software in its entirety and 
+ without modifications, you must retain this notice and the following 
+ text and disclaimers in all such redistributions of the Apple Software. 
+ Neither the name, trademarks, service marks or logos of Apple Inc. may 
+ be used to endorse or promote products derived from the Apple Software 
+ without specific prior written permission from Apple.  Except as 
+ expressly stated in this notice, no other rights or licenses, express or 
+ implied, are granted by Apple herein, including but not limited to any 
+ patent rights that may be infringed by your derivative works or by other 
+ works in which the Apple Software may be incorporated. 
+  
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE 
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION 
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS 
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND 
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS. 
+  
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL 
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION, 
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED 
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE), 
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE 
+ POSSIBILITY OF SUCH DAMAGE. 
+  
+ Copyright (C) 2010 Apple Inc. All Rights Reserved. 
+  
+*/ 
+
+#import "KeychainItemWrapper.h"
+#import <Security/Security.h>
+
+#if ! __has_feature(objc_arc)
+#error THIS CODE MUST BE COMPILED WITH ARC ENABLED!
+#endif
+
+/*
+
+These are the default constants and their respective types,
+available for the kSecClassGenericPassword Keychain Item class:
+
+kSecAttrAccessGroup			-		CFStringRef
+kSecAttrCreationDate		-		CFDateRef
+kSecAttrModificationDate    -		CFDateRef
+kSecAttrDescription			-		CFStringRef
+kSecAttrComment				-		CFStringRef
+kSecAttrCreator				-		CFNumberRef
+kSecAttrType                -		CFNumberRef
+kSecAttrLabel				-		CFStringRef
+kSecAttrIsInvisible			-		CFBooleanRef
+kSecAttrIsNegative			-		CFBooleanRef
+kSecAttrAccount				-		CFStringRef
+kSecAttrService				-		CFStringRef
+kSecAttrGeneric				-		CFDataRef
+ 
+See the header file Security/SecItem.h for more details.
+
+*/
+
+@interface KeychainItemWrapper (PrivateMethods)
+/*
+The decision behind the following two methods (secItemFormatToDictionary and dictionaryToSecItemFormat) was
+to encapsulate the transition between what the detail view controller was expecting (NSString *) and what the
+Keychain API expects as a validly constructed container class.
+*/
+- (NSMutableDictionary *)secItemFormatToDictionary:(NSDictionary *)dictionaryToConvert;
+- (NSMutableDictionary *)dictionaryToSecItemFormat:(NSDictionary *)dictionaryToConvert;
+
+// Updates the item in the keychain, or adds it if it doesn't exist.
+- (void)writeToKeychain;
+
+@end
+
+@implementation KeychainItemWrapper
+{
+    NSMutableDictionary *keychainItemData;		// The actual keychain item data backing store.
+    NSMutableDictionary *genericPasswordQuery;	// A placeholder for the generic keychain item query used to locate the item.
+}
+
+- (id)initWithIdentifier: (NSString *)identifier accessGroup:(NSString *) accessGroup;
+{
+    if (self = [super init])
+    {
+        // Begin Keychain search setup. The genericPasswordQuery leverages the special user
+        // defined attribute kSecAttrGeneric to distinguish itself between other generic Keychain
+        // items which may be included by the same application.
+        genericPasswordQuery = [[NSMutableDictionary alloc] init];
+        
+		[genericPasswordQuery setObject:(__bridge id)kSecClassGenericPassword forKey:(__bridge id)kSecClass];
+        [genericPasswordQuery setObject:identifier forKey:(__bridge id)kSecAttrGeneric];
+		
+		// The keychain access group attribute determines if this item can be shared
+		// amongst multiple apps whose code signing entitlements contain the same keychain access group.
+		if (accessGroup != nil)
+		{
+#if TARGET_IPHONE_SIMULATOR
+			// Ignore the access group if running on the iPhone simulator.
+			// 
+			// Apps that are built for the simulator aren't signed, so there's no keychain access group
+			// for the simulator to check. This means that all apps can see all keychain items when run
+			// on the simulator.
+			//
+			// If a SecItem contains an access group attribute, SecItemAdd and SecItemUpdate on the
+			// simulator will return -25243 (errSecNoAccessForItem).
+#else			
+			[genericPasswordQuery setObject:accessGroup forKey:(__bridge id)kSecAttrAccessGroup];
+#endif
+		}
+		
+		// Use the proper search constants, return only the attributes of the first match.
+        [genericPasswordQuery setObject:(__bridge id)kSecMatchLimitOne forKey:(__bridge id)kSecMatchLimit];
+        [genericPasswordQuery setObject:(__bridge id)kCFBooleanTrue forKey:(__bridge id)kSecReturnAttributes];
+        
+        NSDictionary *tempQuery = [NSDictionary dictionaryWithDictionary:genericPasswordQuery];
+        
+        CFMutableDictionaryRef outDictionary = NULL;
+        
+        if (!SecItemCopyMatching((__bridge CFDictionaryRef)tempQuery, (CFTypeRef *)&outDictionary) == noErr)
+        {
+            // Stick these default values into keychain item if nothing found.
+            [self resetKeychainItem];
+			
+			// Add the generic attribute and the keychain access group.
+			[keychainItemData setObject:identifier forKey:(__bridge id)kSecAttrGeneric];
+			if (accessGroup != nil)
+			{
+#if TARGET_IPHONE_SIMULATOR
+				// Ignore the access group if running on the iPhone simulator.
+				// 
+				// Apps that are built for the simulator aren't signed, so there's no keychain access group
+				// for the simulator to check. This means that all apps can see all keychain items when run
+				// on the simulator.
+				//
+				// If a SecItem contains an access group attribute, SecItemAdd and SecItemUpdate on the
+				// simulator will return -25243 (errSecNoAccessForItem).
+#else			
+				[keychainItemData setObject:accessGroup forKey:(__bridge id)kSecAttrAccessGroup];
+#endif
+			}
+		}
+        else
+        {
+            // load the saved data from Keychain.
+            keychainItemData = [self secItemFormatToDictionary:(__bridge NSDictionary *)outDictionary];
+        }
+		if(outDictionary) CFRelease(outDictionary);
+    }
+    
+	return self;
+}
+
+- (void)setObject:(id)inObject forKey:(id)key 
+{
+    if (inObject == nil) return;
+    id currentObject = [keychainItemData objectForKey:key];
+    if (![currentObject isEqual:inObject])
+    {
+        [keychainItemData setObject:inObject forKey:key];
+        [self writeToKeychain];
+    }
+}
+
+- (id)objectForKey:(id)key
+{
+    return [keychainItemData objectForKey:key];
+}
+
+- (void)resetKeychainItem
+{
+	OSStatus junk = noErr;
+    if (!keychainItemData) 
+    {
+        keychainItemData = [[NSMutableDictionary alloc] init];
+    }
+    else if (keychainItemData)
+    {
+        NSMutableDictionary *tempDictionary = [self dictionaryToSecItemFormat:keychainItemData];
+		junk = SecItemDelete((__bridge CFDictionaryRef)tempDictionary);
+        NSAssert( junk == noErr || junk == errSecItemNotFound, @"Problem deleting current dictionary." );
+    }
+    
+    // Default attributes for keychain item.
+    [keychainItemData setObject:@"" forKey:(__bridge id)kSecAttrAccount];
+    [keychainItemData setObject:@"" forKey:(__bridge id)kSecAttrLabel];
+    [keychainItemData setObject:@"" forKey:(__bridge id)kSecAttrDescription];
+    
+	// Default data for keychain item.
+    [keychainItemData setObject:@"" forKey:(__bridge id)kSecValueData];
+}
+
+- (NSMutableDictionary *)dictionaryToSecItemFormat:(NSDictionary *)dictionaryToConvert
+{
+    // The assumption is that this method will be called with a properly populated dictionary
+    // containing all the right key/value pairs for a SecItem.
+    
+    // Create a dictionary to return populated with the attributes and data.
+    NSMutableDictionary *returnDictionary = [NSMutableDictionary dictionaryWithDictionary:dictionaryToConvert];
+    
+    // Add the Generic Password keychain item class attribute.
+    [returnDictionary setObject:(__bridge id)kSecClassGenericPassword forKey:(__bridge id)kSecClass];
+    
+    // Convert the NSString to NSData to meet the requirements for the value type kSecValueData.
+	// This is where to store sensitive data that should be encrypted.
+    NSString *passwordString = [dictionaryToConvert objectForKey:(__bridge id)kSecValueData];
+    [returnDictionary setObject:[passwordString dataUsingEncoding:NSUTF8StringEncoding] forKey:(__bridge id)kSecValueData];
+    
+    return returnDictionary;
+}
+
+- (NSMutableDictionary *)secItemFormatToDictionary:(NSDictionary *)dictionaryToConvert
+{
+    // The assumption is that this method will be called with a properly populated dictionary
+    // containing all the right key/value pairs for the UI element.
+    
+    // Create a dictionary to return populated with the attributes and data.
+    NSMutableDictionary *returnDictionary = [NSMutableDictionary dictionaryWithDictionary:dictionaryToConvert];
+    
+    // Add the proper search key and class attribute.
+    [returnDictionary setObject:(__bridge id)kCFBooleanTrue forKey:(__bridge id)kSecReturnData];
+    [returnDictionary setObject:(__bridge id)kSecClassGenericPassword forKey:(__bridge id)kSecClass];
+    
+    // Acquire the password data from the attributes.
+    CFDataRef passwordData = NULL;
+    if (SecItemCopyMatching((__bridge CFDictionaryRef)returnDictionary, (CFTypeRef *)&passwordData) == noErr)
+    {
+        // Remove the search, class, and identifier key/value, we don't need them anymore.
+        [returnDictionary removeObjectForKey:(__bridge id)kSecReturnData];
+        
+        // Add the password to the dictionary, converting from NSData to NSString.
+        NSString *password = [[NSString alloc] initWithBytes:[(__bridge NSData *)passwordData bytes] length:[(__bridge NSData *)passwordData length] 
+                                                     encoding:NSUTF8StringEncoding];
+        [returnDictionary setObject:password forKey:(__bridge id)kSecValueData];
+    }
+    else
+    {
+        // Don't do anything if nothing is found.
+        NSAssert(NO, @"Serious error, no matching item found in the keychain.\n");
+    }
+	if(passwordData) CFRelease(passwordData);
+
+	return returnDictionary;
+}
+
+- (void)writeToKeychain
+{
+    CFDictionaryRef attributes = NULL;
+    NSMutableDictionary *updateItem = nil;
+	OSStatus result;
+    
+    if (SecItemCopyMatching((__bridge CFDictionaryRef)genericPasswordQuery, (CFTypeRef *)&attributes) == noErr)
+    {
+        // First we need the attributes from the Keychain.
+        updateItem = [NSMutableDictionary dictionaryWithDictionary:(__bridge NSDictionary *)attributes];
+        // Second we need to add the appropriate search key/values.
+        [updateItem setObject:[genericPasswordQuery objectForKey:(__bridge id)kSecClass] forKey:(__bridge id)kSecClass];
+        
+        // Lastly, we need to set up the updated attribute list being careful to remove the class.
+        NSMutableDictionary *tempCheck = [self dictionaryToSecItemFormat:keychainItemData];
+        [tempCheck removeObjectForKey:(__bridge id)kSecClass];
+		
+#if TARGET_IPHONE_SIMULATOR
+		// Remove the access group if running on the iPhone simulator.
+		// 
+		// Apps that are built for the simulator aren't signed, so there's no keychain access group
+		// for the simulator to check. This means that all apps can see all keychain items when run
+		// on the simulator.
+		//
+		// If a SecItem contains an access group attribute, SecItemAdd and SecItemUpdate on the
+		// simulator will return -25243 (errSecNoAccessForItem).
+		//
+		// The access group attribute will be included in items returned by SecItemCopyMatching,
+		// which is why we need to remove it before updating the item.
+		[tempCheck removeObjectForKey:(__bridge id)kSecAttrAccessGroup];
+#endif
+        
+        // An implicit assumption is that you can only update a single item at a time.
+		
+        result = SecItemUpdate((__bridge CFDictionaryRef)updateItem, (__bridge CFDictionaryRef)tempCheck);
+		NSAssert( result == noErr, @"Couldn't update the Keychain Item." );
+    }
+    else
+    {
+        // No previous item found; add the new one.
+        result = SecItemAdd((__bridge CFDictionaryRef)[self dictionaryToSecItemFormat:keychainItemData], NULL);
+		NSAssert( result == noErr, @"Couldn't add the Keychain Item." );
+    }
+	
+	if(attributes) CFRelease(attributes);
+}
+
+@end


### PR DESCRIPTION
Followup of #8. Secrets should not be stored in NSUserDefaults, but in the keychain.

I implemented the keychain for sharedKey. I assume that sharedKey is the secret, while guid is not a secret. I also added migration code to move existing guid and sharedKey values into the keychain and delete them from the NSUserDefaults.

You should probably repeat this process for pinKey, encryptedPINPassword and passwordPartHash. It's not entirely clear to me how they work and which are considered secret.

You can create multiple KeychainItemWrapper properties on the App Delegate. Each KeychainItemWrapper can contain only one secret (kSecValueData). In addition it can contain something like a corresponding account name (kSecAttrAccount). I don't think the latter is encrypted, but I haven't checked.

Each KeychainItemWrapper needs an identifier (e.g. "Wallet") which I configured in `init`.
